### PR TITLE
Fixed bug in Space class for nearest neighbours search

### DIFF
--- a/mmfeat/space/base.py
+++ b/mmfeat/space/base.py
@@ -50,7 +50,7 @@ class Space(object):
         sims = []
         for other_key in self.space:
             if other_key == key: continue
-            sims = (other_key, self.sim(key, other_key))
+            sims.append((other_key, self.sim(key, other_key)))
 
         if n is None:
             n = len(sims)


### PR DESCRIPTION
The similarities scores were not accumulated in the `sims` list. Every time a new score was calculated, it was assigned to the `sims` variable always resulting in a single tuple.